### PR TITLE
[bugfix/pokemon-page] fixed the issue for image not being fetched. It…

### DIFF
--- a/src/components/common/Card/PokemonCard.tsx
+++ b/src/components/common/Card/PokemonCard.tsx
@@ -13,18 +13,22 @@ type PokemonCardType = {
   pokemon: any;
 };
 
+const RAW_URL = "https://raw.githubusercontent.com/PokeAPI/sprites/master/";
+
 export const PokemonCard = ({ pokemon }: PokemonCardType) => {
   const [loading, setLoading] = useState(true);
   const [colorPalette, setColorPalette] = useState<PaletteColors>({});
   const [image, setImage] = useState<string>("");
   const [moves, setMoves] = useState<PokemonMoveType[]>([]);
 
+  const officialArtWork = pokemon.sprites.other[
+    "official-artwork"
+  ].front_default.replace(RAW_URL, "");
+
   const initialLoading = async () => {
     const pokemonType = checkAndGetPokemonType(pokemon.types[0].type.name);
     const img = `/images/pokemon-type/${pokemonType}.png`;
-    const palette = await getPalette(
-      pokemon.sprites.other["official-artwork"].front_default
-    );
+    const palette = await getPalette(officialArtWork);
     const pokemonRandomMoves = getTwoRandomPokemonMoves(
       pokemon.moves,
       pokemon.stats[0].base_stat
@@ -79,10 +83,7 @@ export const PokemonCard = ({ pokemon }: PokemonCardType) => {
         }}
         className="mx-4 border-4 rounded-lg border-yellow"
       >
-        <img
-          className="w-8/12 mx-auto"
-          src={pokemon.sprites.other["official-artwork"].front_default}
-        />
+        <img className="w-8/12 mx-auto" src={officialArtWork} />
       </div>
 
       {/* Moves */}

--- a/src/pages/pokemon/[slug].tsx
+++ b/src/pages/pokemon/[slug].tsx
@@ -82,7 +82,7 @@ const Pokemon = () => {
         initial={{ opacity: 0, scale: 0.5 }}
         animate={{ opacity: 1, scale: 1 }}
         transition={{
-          delay: 0.5,
+          delay: 0.75,
           duration: 0.3,
           ease: [0, 0.71, 0.2, 1.01],
           scale: {


### PR DESCRIPTION
The pokemon-page is now showing the pokemon card. We got the issue because the pokemonAPI URL for fetching the image was being repeated 2 times, which is weird because we get the response from POKEMON API. For now fixed the issue, by replacing the RAW_URL with empty string. 